### PR TITLE
internal: construct global license DB lazily

### DIFF
--- a/licensedb/internal/nlp.go
+++ b/licensedb/internal/nlp.go
@@ -40,7 +40,7 @@ func investigateReadmeFile(
 	endIndex := matches[len(matches)-1][1]
 	for ; endIndex < len(text)-1 && text[endIndex:endIndex+2] != "\n\n"; endIndex++ {
 	}
-	candidates := globalLicenseDatabase.QueryLicenseText(text[beginIndex:endIndex])
+	candidates := globalLicenseDatabase().QueryLicenseText(text[beginIndex:endIndex])
 
 	beginIndex = matches[0][0]
 	endIndex = beginIndex + 50


### PR DESCRIPTION
Constructing this DB takes about 3s. This is a huge hit when this
package is merely linked in to a binary (e.g. a test) and not used.

Signed-off-by: David Symonds <dsymonds@golang.org>