### PR TITLE
Expose analyse results to api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - go: tip
 
 before_install:
-  - go get -v github.com/golang/lint/golint
+  - go get -v golang.org/x/lint/golint
   - go get -v github.com/haya14busa/goverage
 
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ issue you're facing, or it's a known issue that we're already aware of.
 Pull Requests (PRs) are the main and exclusive way to contribute to the official go-license-detector project.
 In order for a PR to be accepted it needs to pass a list of requirements:
 
-- All PRs must be written in idiomatic Go, formatted according to [gofmt](https://golang.org/cmd/gofmt/), and without any warnings from [go lint](https://github.com/golang/lint) nor [go vet](https://golang.org/cmd/vet/).
+- All PRs must be written in idiomatic Go, formatted according to [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), and without any warnings from [go lint](https://github.com/golang/lint) nor [go vet](https://golang.org/cmd/vet/).
 - New features should be generally covered with tests.
 - The test suite must pass.
 - All PRs have to pass the personal evaluation of at least one of the [maintainers](MAINTAINERS.md).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ license-detector /path/to/project
 license-detector https://github.com/src-d/go-git
 ```
 
-Library (low level for a single license detection):
+Library (for a single license detection):
 
 ```go
 import (
@@ -74,17 +74,18 @@ func main() {
 }
 ```
 
-Library (top level for a convenient data structure that can be formatted as JSON):
+Library (for a convenient data structure that can be formatted as JSON):
 
 ```go
 import (
-	"gopkg.in/src-d/go-license-detector.v2/detection"
-	"fmt"
 	"encoding/json"
+	"fmt"
+
+	"gopkg.in/src-d/go-license-detector.v2/licensedb"
 )
 
 func main() {
-	results := detection.Detect("/path/to/project1", "/path/to/project2")
+	results := licensedb.Analyse("/path/to/project1", "/path/to/project2")
 	bytes, err := json.MarshalIndent(results, "", "\t")
 	if err != nil {
 		fmt.Printf("could not encode result to JSON: %v\n", err)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ license-detector /path/to/project
 license-detector https://github.com/src-d/go-git
 ```
 
-Library:
+Library (low level for a single license detection):
 
 ```go
 import (
@@ -73,6 +73,26 @@ func main() {
 	licenses, err := licensedb.Detect(filer.FromDirectory("/path/to/project"))
 }
 ```
+
+Library (top level for a convenient data structure that can be formatted as JSON):
+
+```go
+import (
+	"gopkg.in/src-d/go-license-detector.v2/detection"
+	"fmt"
+	"encoding/json"
+)
+
+func main() {
+	results := detection.Detect("/path/to/project1", "/path/to/project2")
+	bytes, err := json.MarshalIndent(results, "", "\t")
+	if err != nil {
+		fmt.Printf("could not encode result to JSON: %v\n", err)
+	}
+	fmt.Println(string(bytes))
+}
+```
+
 
 ## Quality
 

--- a/cmd/license-detector/main.go
+++ b/cmd/license-detector/main.go
@@ -37,8 +37,8 @@ func detect(args []string, format string, writer io.Writer) {
 	case "text":
 		for _, res := range results {
 			fmt.Fprintln(writer, res.Arg)
-			if res.Err != nil {
-				fmt.Fprintf(writer, "\t%v\n", res.Err)
+			if res.ErrStr != "" {
+				fmt.Fprintf(writer, "\t%v\n", res.ErrStr)
 				continue
 			}
 			for _, m := range res.Matches {

--- a/cmd/license-detector/main.go
+++ b/cmd/license-detector/main.go
@@ -9,8 +9,9 @@ import (
 	"io"
 	"log"
 	"os"
+
 	"github.com/spf13/pflag"
-	"gopkg.in/src-d/go-license-detector.v2/detection"
+	"gopkg.in/src-d/go-license-detector.v2/licensedb"
 )
 
 func main() {
@@ -30,7 +31,7 @@ func main() {
 // detect runs license analysis on each item in `args`` and outputs
 // the results in the specified `format` to `writer`.
 func detect(args []string, format string, writer io.Writer) {
-	results := detection.Detect(args...)
+	results := licensedb.Analyse(args...)
 
 	switch format {
 	case "text":

--- a/cmd/license-detector/main.go
+++ b/cmd/license-detector/main.go
@@ -8,14 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/url"
 	"os"
-	"sort"
-	"sync"
-
 	"github.com/spf13/pflag"
-	"gopkg.in/src-d/go-license-detector.v2/licensedb"
-	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
+	"gopkg.in/src-d/go-license-detector.v2/detection"
 )
 
 func main() {
@@ -35,22 +30,7 @@ func main() {
 // detect runs license analysis on each item in `args`` and outputs
 // the results in the specified `format` to `writer`.
 func detect(args []string, format string, writer io.Writer) {
-	nargs := len(args)
-	results := make([]result, nargs)
-	var wg sync.WaitGroup
-	wg.Add(nargs)
-	for i, arg := range args {
-		go func(i int, arg string) {
-			defer wg.Done()
-			matches, err := process(arg)
-			res := result{Arg: arg, Matches: matches, Err: err, ErrStr: ""}
-			if err != nil {
-				res.ErrStr = err.Error()
-			}
-			results[i] = res
-		}(i, arg)
-	}
-	wg.Wait()
+	results := detection.Detect(args...)
 
 	switch format {
 	case "text":
@@ -71,47 +51,4 @@ func detect(args []string, format string, writer io.Writer) {
 		}
 		fmt.Fprintf(writer, "%s\n", b)
 	}
-}
-
-// json cannot not marshal error-s as we would expect (we always get "{}")
-// so we have to include ErrStr which is Err.Error()
-type result struct {
-	Arg     string  `json:"project,omitempty"`
-	Matches []match `json:"matches,omitempty"`
-	Err     error   `json:"-"`
-	ErrStr  string  `json:"error,omitempty"`
-}
-
-type match struct {
-	License    string  `json:"license"`
-	Confidence float32 `json:"confidence"`
-}
-
-func process(arg string) ([]match, error) {
-	newFiler := filer.FromDirectory
-	fi, err := os.Stat(arg)
-	if err != nil {
-		if _, err := url.Parse(arg); err == nil {
-			newFiler = filer.FromGitURL
-		}
-	} else if !fi.IsDir() {
-		newFiler = filer.FromSiva
-	}
-
-	resolvedFiler, err := newFiler(arg)
-	if err != nil {
-		return nil, err
-	}
-
-	ls, err := licensedb.Detect(resolvedFiler)
-	if err != nil {
-		return nil, err
-	}
-
-	var matches []match
-	for k, v := range ls {
-		matches = append(matches, match{k, v})
-	}
-	sort.Slice(matches, func(i, j int) bool { return matches[i].Confidence > matches[j].Confidence })
-	return matches, nil
 }

--- a/cmd/license-detector/main_test.go
+++ b/cmd/license-detector/main_test.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/src-d/go-license-detector.v2/licensedb"
 )
 
-func TestMain(t *testing.T) {
+func TestCmdMain(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	detect([]string{"../..", "."}, "json", buffer)
 	var r []licensedb.Result
@@ -19,9 +19,7 @@ func TestMain(t *testing.T) {
 	assert.Equal(t, ".", r[1].Arg)
 	assert.Len(t, r[0].Matches, 2)
 	assert.Len(t, r[1].Matches, 0)
-	assert.Nil(t, r[0].Err)
 	assert.Equal(t, "", r[0].ErrStr)
-	assert.Nil(t, r[1].Err) // json discards
 	assert.Equal(t, "no license file was found", r[1].ErrStr)
 	assert.Equal(t, "Apache-2.0", r[0].Matches[0].License)
 	assert.InDelta(t, 0.9846, r[0].Matches[0].Confidence, 0.001)

--- a/cmd/license-detector/main_test.go
+++ b/cmd/license-detector/main_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-license-detector.v2/detection"
 )
 
 func TestMain(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	detect([]string{"../..", "."}, "json", buffer)
-	var r []result
+	var r []detection.Result
 	json.Unmarshal(buffer.Bytes(), &r)
 	assert.Len(t, r, 2)
 	assert.Equal(t, "../..", r[0].Arg)

--- a/cmd/license-detector/main_test.go
+++ b/cmd/license-detector/main_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/src-d/go-license-detector.v2/detection"
+	"gopkg.in/src-d/go-license-detector.v2/licensedb"
 )
 
 func TestMain(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	detect([]string{"../..", "."}, "json", buffer)
-	var r []detection.Result
+	var r []licensedb.Result
 	json.Unmarshal(buffer.Bytes(), &r)
 	assert.Len(t, r, 2)
 	assert.Equal(t, "../..", r[0].Arg)

--- a/detection/detection.go
+++ b/detection/detection.go
@@ -1,0 +1,77 @@
+package detection
+
+import (
+	"sync"
+	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
+	"os"
+	"net/url"
+	"gopkg.in/src-d/go-license-detector.v2/licensedb"
+	"sort"
+)
+
+// Detect runs license analysis on each item in `args`
+func Detect(args ...string) []Result {
+	nargs := len(args)
+	results := make([]Result, nargs)
+	var wg sync.WaitGroup
+	wg.Add(nargs)
+	for i, arg := range args {
+		go func(i int, arg string) {
+			defer wg.Done()
+			matches, err := process(arg)
+			res := Result{Arg: arg, Matches: matches, Err: err, ErrStr: ""}
+			if err != nil {
+				res.ErrStr = err.Error()
+			}
+			results[i] = res
+		}(i, arg)
+	}
+	wg.Wait()
+
+	return results
+}
+
+// json cannot not marshal error-s as we would expect (we always get "{}")
+// so we have to include ErrStr which is Err.Error()
+// Result gathers license detection results for a project path
+type Result struct {
+	Arg     string  `json:"project,omitempty"`
+	Matches []Match `json:"matches,omitempty"`
+	Err     error   `json:"-"`
+	ErrStr  string  `json:"error,omitempty"`
+}
+
+// Match describes the level of confidence for the detected Licence
+type Match struct {
+	License    string  `json:"license"`
+	Confidence float32 `json:"confidence"`
+}
+
+func process(arg string) ([]Match, error) {
+	newFiler := filer.FromDirectory
+	fi, err := os.Stat(arg)
+	if err != nil {
+		if _, err := url.Parse(arg); err == nil {
+			newFiler = filer.FromGitURL
+		}
+	} else if !fi.IsDir() {
+		newFiler = filer.FromSiva
+	}
+
+	resolvedFiler, err := newFiler(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	ls, err := licensedb.Detect(resolvedFiler)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []Match
+	for k, v := range ls {
+		matches = append(matches, Match{k, v})
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Confidence > matches[j].Confidence })
+	return matches, nil
+}

--- a/detection/detection.go
+++ b/detection/detection.go
@@ -31,9 +31,9 @@ func Detect(args ...string) []Result {
 	return results
 }
 
+// Result gathers license detection results for a project path
 // json cannot not marshal error-s as we would expect (we always get "{}")
 // so we have to include ErrStr which is Err.Error()
-// Result gathers license detection results for a project path
 type Result struct {
 	Arg     string  `json:"project,omitempty"`
 	Matches []Match `json:"matches,omitempty"`

--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -19,7 +19,7 @@ func Analyse(args ...string) []Result {
 		go func(i int, arg string) {
 			defer wg.Done()
 			matches, err := process(arg)
-			res := Result{Arg: arg, Matches: matches, Err: err, ErrStr: ""}
+			res := Result{Arg: arg, Matches: matches}
 			if err != nil {
 				res.ErrStr = err.Error()
 			}
@@ -32,13 +32,10 @@ func Analyse(args ...string) []Result {
 }
 
 // Result gathers license detection results for a project path
-// json cannot not marshal error-s as we would expect (we always get "{}")
-// so we have to include ErrStr which is Err.Error()
 type Result struct {
 	Arg     string  `json:"project,omitempty"`
 	Matches []Match `json:"matches,omitempty"`
-	Err     error   `json:"-"`
-	ErrStr  string  `json:"error,omitempty"`
+	ErrStr     string  `json:"error,omitempty"`
 }
 
 // Match describes the level of confidence for the detected License

--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -1,16 +1,16 @@
-package detection
+package licensedb
 
 import (
-	"sync"
-	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
-	"os"
 	"net/url"
-	"gopkg.in/src-d/go-license-detector.v2/licensedb"
+	"os"
 	"sort"
+	"sync"
+
+	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
 )
 
-// Detect runs license analysis on each item in `args`
-func Detect(args ...string) []Result {
+// Analyse runs license analysis on each item in `args`
+func Analyse(args ...string) []Result {
 	nargs := len(args)
 	results := make([]Result, nargs)
 	var wg sync.WaitGroup
@@ -41,7 +41,7 @@ type Result struct {
 	ErrStr  string  `json:"error,omitempty"`
 }
 
-// Match describes the level of confidence for the detected Licence
+// Match describes the level of confidence for the detected License
 type Match struct {
 	License    string  `json:"license"`
 	Confidence float32 `json:"confidence"`
@@ -63,7 +63,7 @@ func process(arg string) ([]Match, error) {
 		return nil, err
 	}
 
-	ls, err := licensedb.Detect(resolvedFiler)
+	ls, err := Detect(resolvedFiler)
 	if err != nil {
 		return nil, err
 	}

--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -35,7 +35,7 @@ func Analyse(args ...string) []Result {
 type Result struct {
 	Arg     string  `json:"project,omitempty"`
 	Matches []Match `json:"matches,omitempty"`
-	ErrStr     string  `json:"error,omitempty"`
+	ErrStr  string  `json:"error,omitempty"`
 }
 
 // Match describes the level of confidence for the detected License


### PR DESCRIPTION
So clients can benefit from a rich data structure that contains licence detection results
for one or more project paths and that can be parsed as JSON.

The json data structure was already available in main.go,
so I merely moved it to a top level go file to make it easier to expose.

Signed-off-by: Sebastien Bonnet sebastien.bonnet@ymail.com`