### PR TITLE
Add file matches to detection result

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/shogo82148/go-shuffle v0.0.0-20170808115208-59829097ff3b h1:VI1u+o2KZ
 github.com/shogo82148/go-shuffle v0.0.0-20170808115208-59829097ff3b/go.mod h1:2htx6lmL0NGLHlO8ZCf+lQBGBHIbEujyywxJArf+2Yc=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:/vdW8Cb7EXrkqWGufVMES1OH2sU9gKVb2n9/1y5NMBY=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spf13/pflag v1.0.0 h1:oaPbdDe/x0UncahuwiPxW1GYJyilRAdsPnq3e1yaPcI=
 github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/src-d/gcfg v1.3.0 h1:2BEDr8r0I0b8h/fOqwtxCEiq2HJu8n2JGZJQFGXWLjg=

--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -67,7 +67,7 @@ func process(arg string) ([]Match, error) {
 
 	var matches []Match
 	for k, v := range ls {
-		matches = append(matches, Match{k, v})
+		matches = append(matches, Match{k, v.Confidence})
 	}
 	sort.Slice(matches, func(i, j int) bool { return matches[i].Confidence > matches[j].Confidence })
 	return matches, nil

--- a/licensedb/api/api.go
+++ b/licensedb/api/api.go
@@ -1,0 +1,8 @@
+package api
+
+// Match is a detection result of a license with a confidence (0.0 - 1.0)
+// and a mapping of files to confidence.
+type Match struct {
+	Files      map[string]float32
+	Confidence float32
+}

--- a/licensedb/dataset_test.go
+++ b/licensedb/dataset_test.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-license-detector.v2/licensedb/api"
 	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDataset(t *testing.T) {
@@ -16,7 +18,7 @@ func TestDataset(t *testing.T) {
 	defer rootFiler.Close()
 	projects, err := rootFiler.ReadDir("")
 	assert.Nil(t, err)
-	licenses := map[string]map[string]float32{}
+	licenses := map[string]map[string]api.Match{}
 	mutex := sync.Mutex{}
 	wg := sync.WaitGroup{}
 	wg.Add(len(projects))

--- a/licensedb/internal/assets/bindata.go
+++ b/licensedb/internal/assets/bindata.go
@@ -183,8 +183,8 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"licenses.tar": licensesTar,
-	"urls.csv": urlsCsv,
-	"names.csv": namesCsv,
+	"urls.csv":     urlsCsv,
+	"names.csv":    namesCsv,
 }
 
 // AssetDir returns the file names below a certain
@@ -226,10 +226,11 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"licenses.tar": &bintree{licensesTar, map[string]*bintree{}},
-	"names.csv": &bintree{namesCsv, map[string]*bintree{}},
-	"urls.csv": &bintree{urlsCsv, map[string]*bintree{}},
+	"names.csv":    &bintree{namesCsv, map[string]*bintree{}},
+	"urls.csv":     &bintree{urlsCsv, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -278,4 +279,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/licensedb/licensedb.go
+++ b/licensedb/licensedb.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	paths "path"
 
+	"gopkg.in/src-d/go-license-detector.v2/licensedb/api"
 	"gopkg.in/src-d/go-license-detector.v2/licensedb/filer"
 	"gopkg.in/src-d/go-license-detector.v2/licensedb/internal"
 )
@@ -15,7 +16,7 @@ var (
 
 // Detect returns the most probable reference licenses matched for the given
 // file tree. Each match has the confidence assigned, from 0 to 1, 1 means 100% confident.
-func Detect(fs filer.Filer) (map[string]float32, error) {
+func Detect(fs filer.Filer) (map[string]api.Match, error) {
 	files, err := fs.ReadDir("")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds file matches to the detection result, changing the API as minimally as possible from `map[string]float32` to `map[string]api.Match` where `api.Match` is
```go
type Match struct {
    Confidence float32
    Files map[string]float32
}
```
I had to add an `api` package in order not to have any conversions or cyclic dependencies between the `internal` and `licensedb` package.

Fixes #55 