### PR TITLE
Make it compatible with go-git > 4.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Don't commit go.sum go modules file
+go.sum

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,7 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )
 
-replace gopkg.in/russross/blackfriday.v2 => github.com/russross/blackfriday/v2 v2.0.1
+replace (
+	github.com/sergi/go-diff v1.0.0 => github.com/sergi/go-diff v0.0.0-20180205163309-da645544ed44
+	gopkg.in/russross/blackfriday.v2 => github.com/russross/blackfriday/v2 v2.0.1
+)

--- a/go.mod
+++ b/go.mod
@@ -1,47 +1,29 @@
 module gopkg.in/src-d/go-license-detector.v3
 
 require (
-	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 // indirect
-	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 // indirect
-	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/dgryski/go-minhash v0.0.0-20170608043002-7fe510aff544 // indirect
 	github.com/dgryski/go-spooky v0.0.0-20170606183049-ed3d087f40e2 // indirect
 	github.com/ekzhu/minhash-lsh v0.0.0-20171225071031-5c06ee8586a1
-	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
-	github.com/gliderlabs/ssh v0.1.1 // indirect
-	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/hhatto/gorst v0.0.0-20171128071645-7682c8a25108
-	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jdkato/prose v1.1.0
-	github.com/kevinburke/ssh_config v0.0.0-20180127194858-0ff8514904a8 // indirect
-	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747 // indirect
 	github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb // indirect
 	github.com/neurosnap/sentences v1.0.6 // indirect
-	github.com/pelletier/go-buffruneio v0.2.0 // indirect
-	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sergi/go-diff v0.0.0-20180205163309-da645544ed44
+	github.com/pkg/errors v0.8.1
+	github.com/sergi/go-diff v1.0.0
 	github.com/shogo82148/go-shuffle v0.0.0-20170808115208-59829097ff3b // indirect
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
 	github.com/spf13/pflag v1.0.0
-	github.com/src-d/gcfg v1.3.0 // indirect
-	github.com/stretchr/testify v1.2.1
-	github.com/xanzy/ssh-agent v0.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20180206190813-d9133f546934 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/exp v0.0.0-20171209012058-072991165226
-	golang.org/x/net v0.0.0-20180208041118-f5dfe339be1d
-	golang.org/x/text v0.0.0-20180208041248-4e4a3210bb54
+	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
+	golang.org/x/text v0.3.2
 	gonum.org/v1/gonum v0.0.0-20180205154402-996b88e8f894
 	gopkg.in/neurosnap/sentences.v1 v1.0.6 // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.1
-	gopkg.in/src-d/go-billy-siva.v4 v4.3.0
-	gopkg.in/src-d/go-billy.v4 v4.3.0
-	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0 // indirect
-	gopkg.in/src-d/go-git.v4 v4.7.0
-	gopkg.in/src-d/go-siva.v1 v1.5.0 // indirect
-	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/src-d/go-billy-siva.v4 v4.6.0
+	gopkg.in/src-d/go-billy.v4 v4.3.2
+	gopkg.in/src-d/go-git.v4 v4.13.1
 )
 
 replace gopkg.in/russross/blackfriday.v2 => github.com/russross/blackfriday/v2 v2.0.1

--- a/licensedb/filer/filer.go
+++ b/licensedb/filer/filer.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
@@ -221,10 +222,7 @@ func FromSiva(path string) (Filer, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create a Siva filesystem from %s", path)
 	}
-	sivaStorage, err := filesystem.NewStorage(fs)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create a new storage backend for Siva file %s", path)
-	}
+	sivaStorage := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	repo, err := git.Open(sivaStorage, tmpFs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to open the Git repository from Siva file %s", path)


### PR DESCRIPTION
I'm using this as a library in a project that uses go-git 4.13.1, filer.go uses an incompatible method signature when initializing the siva filesystem.

I haven't done much due diligence but it seemed to be an easy fix.