### PR TITLE
Correct the blackfriday import reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+go.sum

--- a/go.mod
+++ b/go.mod
@@ -10,17 +10,17 @@ require (
 	github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb // indirect
 	github.com/neurosnap/sentences v1.0.6 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/shogo82148/go-shuffle v0.0.0-20170808115208-59829097ff3b // indirect
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
 	github.com/spf13/pflag v1.0.0
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/exp v0.0.0-20171209012058-072991165226
+	golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/text v0.3.2
-	gonum.org/v1/gonum v0.0.0-20180205154402-996b88e8f894
+	gonum.org/v1/gonum v0.6.1
 	gopkg.in/neurosnap/sentences.v1 v1.0.6 // indirect
-	gopkg.in/russross/blackfriday.v2 v2.0.1
 	gopkg.in/src-d/go-billy-siva.v4 v4.3.0
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
@@ -30,5 +30,6 @@ require (
 replace (
 	github.com/sergi/go-diff v1.0.0 => github.com/sergi/go-diff v0.0.0-20180205163309-da645544ed44
 	golang.org/x/text v0.3.2 => golang.org/x/text v0.3.0
-	gopkg.in/russross/blackfriday.v2 => github.com/russross/blackfriday/v2 v2.0.1
 )
+
+go 1.13

--- a/licensedb/internal/processors/markup.go
+++ b/licensedb/internal/processors/markup.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	rst "github.com/hhatto/gorst"
-	"gopkg.in/russross/blackfriday.v2"
+	"github.com/russross/blackfriday/v2"
 )
 
 // Markdown converts Markdown to plain text. It tries to revert all the decorations.


### PR DESCRIPTION
The module path for rusross/blackfriday is now
github.com/russross/blackfriday/v2:
https://github.com/russross/blackfriday/blob/v2/go.mod.

I noticed you haven't checked in the `go.sum` file, is that intentional? I've kept it in for now.