### PR TITLE
add copying to list of license file names

### DIFF
--- a/licensedb/internal/investigation.go
+++ b/licensedb/internal/investigation.go
@@ -35,6 +35,7 @@ var (
 		"bsd",
 		"mit",
 		"apache",
+		"copying",
 	}
 
 	// License file extensions. Combined with the fileNames slice


### PR DESCRIPTION
Some project use a `COPYING` file for their license. This PR adds this file to the license list that is used to find files to scan. As a reference, my project has 72 dependencies for which the detector was able to detect 64. With the copying file it detected licenses in all repo's, so it looks like it's quite common.

The `COPYING` file seems to be a convention used in the GNU project (http://www.gnu.org/licenses/gpl-howto.html).

example: https://github.com/aristanetworks/goarista